### PR TITLE
Utilize indexes by not using % before search terms. Only after.

### DIFF
--- a/app/controllers/api/charity_controller.rb
+++ b/app/controllers/api/charity_controller.rb
@@ -19,8 +19,8 @@ class Api::CharityController < Api::BaseController
     charity_list = []
 
     #let's not sqli ourselves in the API
-    nameq = "%#{query}%"
-    cityq = "%#{city}%"
+    nameq = "#{query}%"
+    cityq = "#{city}%"
     #q = q.gsub!(' ','%')
     
     if cityq == "%%"


### PR DESCRIPTION
Like I said, I haven't tested this whatsoever but I'm pretty sure that using searches like `%charity_name%` removes the effectiveness of the indexes you are using. `charity_name%` should get you the same results but utilize the indexes. The only issue is if they leave out parts of the words like The, etc. 

Just a hunch. May be something that gets thrown away.
